### PR TITLE
Lots of fixes

### DIFF
--- a/plugins/language/french/french.txt
+++ b/plugins/language/french/french.txt
@@ -1,3 +1,4 @@
+0 ISO-8859-1
 2 Toutes les machines
 9 Recherche multicritères
 13 Envoyer
@@ -7,7 +8,7 @@
 20 Logiciel
 23 Machine
 24 Utilisateur
-25 Système
+25 Système d'exploitation
 26 Mémoire
 27 Vitesse mémoire (MHz)
 28 Nombre de machines
@@ -25,13 +26,14 @@
 46 Dernier inventaire
 48 Affichage système
 49 Nom
-50 Espace de Swap
+50 Espace de swap
 51 Commentaires
 52 Visible
 53 Description
 54 Processeur(s)
 55 Nombre
 56 Données administratives
+57 GB
 61 Carte vidéo
 62 Résolution
 63 Stockage
@@ -44,14 +46,14 @@
 79 Imprimante(s)
 80 Libellé
 81 Etat
-82 Réseau(x)
+82 Réseau
 83 Capacité
 84 Interface
 85 Lettre
 86 Système de fichiers
 87 Total
 88 Libre
-90 Résultat(s)
+90 résultat(s)
 91 Périphérique(s) d'entrée
 92 Disque(s)
 93 Contrôleur(s)
@@ -69,10 +71,10 @@
 116 Ajouter
 119 Voulez-vous vraiment supprimer la machine
 122 Supprimer
-129 RESSEMBLE
-130 DIFFERENT
+129 Ressemble
+130 Different
 134 Ajout d'un nouveau fichier dans la base
-135 Attention, vous allez supprimer ce fichier définitivement !
+135 <b>Avertissement:</b> vous allez supprimer ce fichier définitivement!
 137 Fichier
 140 Super administrateurs
 141 Administrateurs
@@ -88,31 +90,31 @@
 175 Doublons
 176 IPs
 177 Fusionner les lignes redondantes
-178 Machines par tag
+178 Machines par TAG
 180 Utilisateur ou mot de passe incorrect
 182 Machines ayant une étiquette donné
 183 Télécharger
 184 Ce fichier ne contient pas "use constant version"
 185 La version doit être supérieure ou égale à 1
-186 Cette archive ne contient pas ver
-187 Ce fichier n'est pas une archive zip valide
+186 Cette archive ne contient pas version
+187 Ce fichier n'est pas une archive ZIP valide
 188 Retour
 189 Vous devez sélectionner au moins deux machines
-190 Accountinfo:
+190 Information sur le compte:
 191 supprimées
 192 Résumé redondance
-193 Nom d'hôte + Numéro de série
-194 Nom d'hôte + Adresse MAC
-195 Adresse MAC + Numéro de série
+193 Nom d'hôte + numéro de série
+194 Nom d'hôte + adresse MAC
+195 Adresse MAC + numéro de série
 196 Nom d'hôte uniquement
 197 Numéro de série uniquement
 198 Adresse MAC uniquement
 199 Redondances
 200 Relai correspondant diminué
-201 PLUS PETIT
-202 PLUS GRAND
-203 ENTRE
-204 HORS DE
+201 Plus petit
+202 Plus grand
+203 Entre
+204 Hors de
 205 Actif
 206 récupérées pour
 207 Passerelle
@@ -124,17 +126,17 @@
 213 Valeur de la clé
 214 Imprimer cette page
 215 Tout afficher
-216 ASSETTAG
+216 Asset TAG
 217 Mot de passe
 218 Versions des agents
 219 interfaces réseau non inventoriées
 220 supprimé
 221 Machines collectant des IPs
-222 Attention ! Toutes les machines cochées seront fusionnées en une seule machine ! Etes-vous sûr ?
+222 <b>Avertissement:</b> toutes les machines cochées seront fusionnées en une seule machine! Etes-vous sûr?
 223 Information
 224 Valeur
-225 Admininfo
-226 a bien été supprimé de la table accountinfo
+225 Information administrative
+226 a bien été supprimé de la tableau "accountinfo"
 227 Etes-vous sûr de vouloir supprimer la colonne
 228 Entrer le nom de la nouvelle donnée administrative
 229 Texte (255)
@@ -142,7 +144,7 @@
 231 Réel
 232 Date
 233 Données actuelles
-234 a bien été enregistré dans la table
+234 a bien été enregistré dans la tableau
 235 Utilisateurs
 236 Changer mot de passe
 237 Nouveau mot de passe
@@ -152,13 +154,13 @@
 241 Votre mot de passe a bien été changé
 242 Administrateur
 243 Utilisateur
-244 Ajouter un nouvel utilisateur
+244 Ajouter nouvel utilisateur
 245 a bien été supprimé
 246 Etes-vous sûr de vouloir supprimer l'utilisateur
 247 Login MySQL
 248 Mot de passe MySQL
 249 Impossible de se connecter à MySQL sur localhost, merci d'entrer un login/mot de passe MySQL valide
-250 MySQL HostName
+250 MySQL hostname
 251 Déconnexion
 252 Nom (au choix)
 253 Ruche registre
@@ -167,11 +169,11 @@
 256 Sélectionnez la requête registre à modifier
 257 Clé de registre
 258 Valeur clé de registre
-259 Erreur, la donnée n'a pas pu être créée (merci de ne pas utiliser de caractères spéciaux)
+259 <b>Erreur:</b> la donnée n'a pas pu être créée (merci de ne pas utiliser de caractères spéciaux)!
 260 Fichier label modifié
 261 Fichier label détruit
 262 Entrez un label
-263 Modifier le label
+263 Modifier label
 264 Actuellement aucun fichier label
 265 Peu importe
 266 Date invalide
@@ -200,15 +202,15 @@
 289 Détail des réseaux interconnectés
 290 Interrogation par IP
 291 Mode expert
-292 Ajout / suppression d'un périphérique
+292 Ajout/suppression d'un périphérique
 293 Types de périphériques
 294 Noms des sous-réseaux
 295 Localisation
-296 Id
-297 Ne peut écrire dans le répertoire
+296 ID
+297 Ne peut pas écrire dans le répertoire
 298 Tous les champs doivent être remplis
 299 Adresse IP invalide (format valide: x.x.x.x)
-300 Masque invalide: format valide: x.x.x.x
+300 Masque invalide (format valide: x.x.x.x)
 301 Réseau inséré
 302 Réseau supprimé
 303 Ajouter un sous-réseau
@@ -225,36 +227,36 @@
 314 Machines IpDiscover de la passerelle
 315 Hôtes non inventoriés
 316 Sous-réseau
-317 ANALYSE
+317 Analyse
 318 Nom DNS
 319 Résultat d'analyse du réseau
 320 Cette analyse a déjà été effectuée le
-321 voulez-vous voir les données en cache ?
+321 Voulez-vous voir les données en cache?
 322 Données issues du cache
 323 datent du
-324 HOTES EVALUES
+324 Hotes evalues
 325 vide
 326 pas de masque entré
 327 Détails de la machine
 328 Découverte
 329 Inventoriée
 330 Nom NetBIOS
-331 Numéro réseau
+331 Adresse réseau
 332 Patientez...
 333 Ajout d'un nouveau périphérique
 334 Liste des périphériques
 335 Type de matériel
 336 Description du périphérique
-337 L'EXECUTABLE N'A RIEN RENVOYE
+337 L'executable n'a rien renvoye
 338 Mode limité
 339 Vous devez disposer de ipdiscover-util.pl (Linux uniquement) pour plus de fonctionnalités
 340 Afficher
-341 ne peut être lancé, vous devez mettre les droits d'exécution
+341 ne peut être lancé. Vous devez mettre les droits d'exécution
 342 Vous devez mettre les droits d'écriture sur le répertoire racine pour pouvoir utiliser
 344 Erreur
-345 L'ANALYSE EST DEJA EN COURS, MERCI DE REESSAYER PLUS TARD
-346 AVANT
-347 APRES
+345 L'analyse est deja en cours. Merci de reessayer plus tard
+346 Avant
+347 Apres
 348 Utilisateur Windows
 349 Ajouter colonne
 350 Type de processeur
@@ -269,7 +271,7 @@
 359 Numéro de série écran
 360 Fabrication (semaine/année)
 362 Le réseau
-363 existe déjà
+363 Existe déjà
 364 Inventoriés
 365 Non inventoriés
 366 Identifiés
@@ -281,16 +283,16 @@
 372 Choisissez les composants à afficher
 373 Utilisateur enregistré
 374 Utilisateur modifié
-375 Version Agent OCS-NG
+375 l'agent OCS-NG version
 376 Ordinateur verrouillé. Merci de réessayer plus tard
 377 Vitesse CPU (MHz)
 380 Dictionnaire
-381 Nombre installation
+381 nombre d'installations
 382 Nom du logiciel
 383 La page
-384 TOUT déplacer
+384 Tout déplacer
 385 Vers une nouvelle catégorie
-386 OU
+386 Ou
 387 Vers une catégorie existante
 388 Catégorie
 389 Rien
@@ -302,8 +304,8 @@
 396 Reset
 397 Aller à la catégorie
 398 Liste des catégories
-410 EXACTEMENT
-411 Vous ne devez entrer que des chiffres !
+410 Exactement
+411 Vous ne devez entrer que des chiffres!
 412 Fonctionnalité de recherche dans le registre
 413 Fonctionnalité de mise à jour automatique
 414 Fonctionnalité de déploiement automatique de l'agent
@@ -311,14 +313,14 @@
 416 Fonctionnalité de log sur le serveur
 417 Fonctionnalité de télédéploiement (agent et serveur)
 418 Fonctionnalité d'inventaires différentiels
-419 Nombre de jour maximal avant qu'une machine ipdiscover ne soit remplacée.
+419 Nombre de jour maximal avant qu'une machine IpDiscover ne soit remplacée
 420 Télédéploiement: voir documentation.
 421 Télédéploiement: voir documentation.
 422 Télédéploiement: voir documentation.
-423 Télédéploiement: voir documentation (Les paquets ayant une valeur supérieure ou égale ne seront plus téléchargés).
+423 Télédéploiement: voir documentation (les paquets ayant une valeur supérieure ou égale ne seront plus téléchargés).
 424 Validité d'un paquet à compter de sa prise en compte par l'agent
 425 Nombre d'ordinateurs remontant les machines de leurs réseaux
-426 Validité d'un inventaire.<br>(ALWAYS: toujours inventorié, NEVER:inventaires désactivés)
+426 Validité d'un inventaire.<br>(always: toujours inventorié. never: inventaires désactivés)
 427 Définit les critères devant être identiques pour qu'une fusion automatique ait lieu
 428 Télédéployer
 429 Fréquence
@@ -333,63 +335,63 @@
 438 Création d'un nouveau paquet
 439 Protocole
 440 Priorité
-441 Algorithme de digest
-442 Encodage digest
+441 Algorithme de "digest"
+442 Encodage "digest"
 443 Action
 444 Commande
 445 Chemin
 446 Nom du fichier
-447 Interactions utilisateur
+447 Notifications de l'utilisateur
 448 Prévenir utilisateur
 449 Texte
 450 Compte à rebours
 451 L'utilisateur peut annuler
 452 L'utilisateur peut remettre à plus tard
 453 La fin de l'installation nécessite une intervention utilisateur
-454 NON
-455 OUI
+454 Non
+455 Oui
 456 Exécuter
 457 Stocker
 458 Lancer
 459 Le compte à rebours doit être un nombre
 460 Identifiant unique
-461 Digest
+461 "Digest"
 462 Taille totale
 463 Taille fragment
 464 Nombre de fragments
 465 Activation de paquets
-466 ATTENTION: Le fichier d'information est introuvable à l'adresse
-467 ATTENTION: Les fragments sont introuvables à l'adresse
-468 Etes-vous sûr de vouloir tout de même activer le paquet avec ces paramètres ?
-469 Paquet activé, il peut maintenant être affecté
+466 <b>Avertissement:</b> le fichier d'information est introuvable à l'adresse!
+467 <b>Avertissement:</b> les fragments sont introuvables à l'adresse!
+468 Etes-vous sûr de vouloir tout de même activer le paquet avec ces paramètres?
+469 Paquet activé. Il peut maintenant être affecté
 470 Serveur https
 471 Serveur de fichiers
-472 ERREUR: Ne peut supprimer le répertoire
+472 <b>Erreur:</b> ne peut supprimer le répertoire!
 473 Le timestamp doit être un nombre
 474 Le timestamp doit faire dix chiffres de long
 475 Timestamp
 476 Ou activer un paquet manuellement
 477 Affecter un paquet
 478 Machine(s)
-479 PAS DE MACHINE SELECTIONNEE
+479 Pas de machine selectionnee
 480 fragments
 481 Paquets activés
-482 ATTENTE NOTIFICATION
-483 Valider SUCCES
+482 Attente notification
+483 Valider succes
 484 Fréquence personnalisée
 485 Toujours inventorié
 486 Jamais inventorié
 487 Personnalisé
 488 Défaut
 489 Comportement IpDiscover
-490 Forcé JAMAIS IpDiscover du réseau
-491 Forcé TOUJOURS IpDiscover du réseau
-492 ELUE IpDiscover du réseau
+490 Forcé jamais IpDiscover du réseau
+491 Forcé toujours IpDiscover du réseau
+492 Elue IpDiscover du réseau
 493 Eligible
 494 Fréquence d'inventaire personnalisée
 495 Inventorier tous les
-496 jours
-497 Par défaut, utilise le paramètre 'FREQUENCY' des options générales.
+496 jour(s)
+497 Par défaut, utilise le paramètre "FREQUENCY" des options générales
 498 Paquet
 499 Serveur
 500 Traitements personnalisés
@@ -399,9 +401,9 @@
 504 Non élu
 505 Eligible
 506 Non éligible
-507 AYANT
-508 N'AYANT PAS
-509 INDIFFERENT
+507 Ayant
+508 N'ayant pas
+509 Indifferent
 510 Pas de paquet
 511 secondes
 512 Télédéploiement
@@ -411,14 +413,14 @@
 516 Ko
 517 Cette option ne peut être affectée que pour une machine à la fois
 518 Forcer IpDiscover
-519 Machine déjà ELUE ipdiscover pour le réseau
-520 Machine déjà FORCEE ipdiscover pour le réseau
-521 Machine déjà FORCEE inéligible ipdiscover
+519 Machine déjà elue IpDiscover pour le réseau
+520 Machine déjà forcee IpDiscover pour le réseau
+521 Machine déjà forcee inéligible IpDiscover
 522 Machine standard
 523 Remettre dans l'état par défaut
-524 Ne PLUS JAMAIS affecter
-525 ETES-VOUS SUR ?
-526 PAS DE MACHINE AFFECTEE
+524 Ne plus jamais affecter
+525 Etes-vous sur?
+526 Pas de machine affectee
 527 Janvier
 528 Février
 529 Mars
@@ -440,11 +442,11 @@
 545 Samedi
 546 dans l'état
 547 tous
-548 Tout sauf SUCCESS
+548 Tout sauf success
 549 Fichier (déployé sur les ordinateurs clients)
-550 Fichier (facultatif, peut être utilisé par "exécuter")
+550 Fichier (facultatif. Peut être utilisé par "exécuter")
 551 Ce nom de paquet est déjà utilisé
-552 <i>Vous devez faire une recherche multicritères puis cliquer sur 'Télédéployer' pour affecter un de ces paquets activés à des machines<br>Vous pouvez aussi affecter un paquet à une machine unique en utilisant l'onglet 'Traitements personnalisés' dans les détails d'une machine</i>.
+552 <i>Vous devez faire une recherche multicritères puis cliquer sur "télédéployer" pour affecter un de ces paquets activés à des machines<br>Vous pouvez aussi affecter un paquet à une machine unique en utilisant l'onglet "traitements personnalisés" dans les détails d'une machine</i>.
 553 Clé Windows
 554 Ecran: numéro de série
 555 Ecran: fabricant
@@ -458,16 +460,16 @@
 563 Constructeur
 564 Fréquence de lancement de l'agent par le service
 565 Adresse utilisée pour les imports locaux
-567 Latence de l'ipdiscover
-568 RAM(MB)
-569 CPU(MHz)
+567 Latence de l'IpDiscover
+568 RAM (MB)
+569 CPU (MHz)
 570 Aide
 571 Tout valider
 572 Succès
 573 Erreurs
 574 Stats
 575 Désaffecter non notifiés
-576 Ipdiscover personnalisé
+576 IpDiscover personnalisé
 577 Nom du groupe
 580 Toutes les machines (rejouer)
 581 Toutes les machines (cache)
@@ -484,38 +486,38 @@
 592 Exclure statiquement
 593 Date de création
 594 Régénération du cache
-595 GROUPE STATIQUE PUR
-596 INCLU DYNAMIQUEMENT
-597 EXCLU STATIQUEMENT
+595 Groupe statique pur
+596 Inclu dynamiquement
+597 Exclu statiquement
 598 Inclure
 600 Exclure
 601 Affectation de masse
 602 Vous devez envoyer un fichier
-603 Aucune machine n'a été trouvée, merci de vérifier votre fichier
-604 machine(s) affectée(s) avec succès.
+603 Aucune machine n'a été trouvée. Merci de vérifier votre fichier
+604 machine(s) affectée(s) avec succès
 605 machine(s) en erreur
 606 Fichier des machines à affecter
 607 Groupe
 608 créé
 609 écrasé
-610 INCLU STATIQUEMENT
-611 PAS CACHE
-612 STATIQUE
-613 DYNAMIQUE
-614 EXCLU
+610 Inclu statiquement
+611 Pas cache
+612 Statique
+613 Dynamique
+614 Exclu
 615 Requête
 616 Périmètre de l'utilisateur
 617 Nouveau
 618 Périmètre
 619 Utilisateur restreint
-620 <br>Vous n'avez aucune machine affectée, merci de faire une demande d'affectation de droits<br><br> en spécifiant sur quels tags vous devez avoir la visibilité.</center>
+620 Aucun ordinateur dans votre périmètre
 621 Ce groupe n'a pas été créé. Ce nom existe déjà.
 622 En cache
 623 L'information que vous essayez de voir n'existe pas.
-624 Voulez-vous vraiment supprimer le groupe
+624 Voulez-vous vraiment supprimer le groupe?
 625 Valider les modifications
 626 Annuler les modifications
-627 Au moins un des champs est vide... Mise à jour non effectuée.
+627 Au moins un des champs est vide. Mise à jour non effectuée.
 628 Serveurs de redistribution
 629 Nouveau groupe de redistribution
 630 Un groupe de redistribution existants
@@ -525,68 +527,68 @@
 634 Action désirée
 635 Nouveau nom
 637 Remplacer
-638 LE NOM DU GROUPE NE PEUT ETRE VIDE
-639 CE GROUPE DE REDISTRIBUTION N'EXISTE PAS
+638 Le nom du groupe ne peut etre vide
+639 Ce groupe de redistribution n'existe pas
 640 Etes-vous sûr de vouloir supprimer
 641 Administration des serveurs de redistribution
 642 le groupe
-643 TOUTES les machines
-644 la machine
-645 DETAILS DU GROUPE
+643 Toutes les machines
+644 cette machine
+645 Details du groupe
 646 URL
-647 NUMERO DU PORT
-648 REPERTOIRE STORE
-649 AUTOMATIQUE
-650 MANUELLE
+647 Numero du port
+648 Repertoire store
+649 Automatique
+650 Manuelle
 651 Groupe de redistribution
 652 Machine(s)
 653 Blacklist d'adresse MAC
-654 Entrez une nouvelle adresse MAC à blacklister
-655 Insertion effectuée
+654 Entrer une nouvelle adresse MAC à blacklister
+655 Insertion effectuée!
 656 Cette donnée existe déjà dans la liste
-657 Les champs en rouge sont en erreur!!! (champs vides ou taille <2)
-658 machines n'ont pas de serveurs de redistribution. <br>Il faut donc affecter ce paquet individuellement.
+657 Les champs en rouge sont en erreur! (champs vides ou taille <2)
+658 machines n'ont pas de serveurs de redistribution.<br>Il faut donc affecter ce paquet individuellement.
 659 machines ont déjà ce paquet télédéployé. Le statut de ce paquet pour ces machines est donc à nouveau
-660 GROUPE DE REDISTRIBUTION INEXISTANT
-661 PAQUETS POUR LA REDISTRIBUTION
+660 Groupe de redistribution inexistant
+661 Paquets pour la redistribution
 662 Règles d'affectation
-663 PROBLEME INTERNE
+663 Probleme interne
 664 Action effectuée
-665 AUCUNE MACHINE SELECTIONNEE. GROUPE DE REDISTRIBUTION NON CREE
+665 Aucune machine selectionnee. Groupe de redistribution non cree
 666 Groupe de redistribution créé
-667 POUR LE PAQUET
+667 Pour le paquet
 668 Affecter avec quelle règle?
-669 ATTENTION: il existe des doublons de priorité<br>Une seule règle sera retenue!
+669 <b>Avertissement:</b> il existe des doublons de priorité<br>Une seule règle sera retenue!
 670 Une règle porte déjà ce nom
-672 Cette règle n'existe pas!!!
+672 Cette règle n'existe pas!
 673 Administration des règles d'affectation
-674 NOM DE LA REGLE
-675 PRIORITE
-676 VALEUR MACHINE
-677 OPERATEUR
-678 VALEUR SERVEUR
-679 NOM
-680 DOMAINE
-681 UTILISATEUR
+674 Nom de la regle
+675 Priorite
+676 Valeur machine
+677 Operateur
+678 Valeur serveur
+679 Nom
+680 Domaine
+681 Utilisateur
 682 Ajouter une condition supplémentaire
 683 Valider la règle
 684 Les champs suivants doivent être saisis
 685 Ajouter une règle
 686 La condition
-687 Vous ne pouvez pas le supprimer.
+687 Vous ne pouvez pas le supprimer!
 688 Des paquets sont affectés sur ce groupe!
 689 Des paquets sont affectés sur ce serveur!
 690 Vous ne pouvez pas supprimer toutes les machines.
 691 Valeurs génériques: $IP$ et $NAME$
-692 Vous modifiez TOUTES les valeurs des serveurs
-693 Vous modifiez les valeurs du serveur suivant:
+692 Vous modifierez toutes les valeurs des serveurs
+693 Vous modifierez les valeurs du serveur suivant:
 694 Pour retrouver les valeurs par défaut, valider les champs à vide
-695 Vous modifiez le groupe de redistribution
+695 Vous modifierez le groupe de redistribution
 696 Visualiser les paquets activés à affecter sur
 697 une machine
 698 un groupe de redistribution
 699 Etes-vous sûr de vouloir affecter ce paquet à ces machines?
-700 Choix Blacklist
+700 Choix blacklist
 701 Blacklist de numéro de série
 702 Entrez un nouveau numéro de série à blacklister
 703 Blacklist
@@ -597,7 +599,7 @@
 708 cette adresse MAC
 709 Cycles de latence personnalisés
 710 Paramètres de téléchargements personnalisés
-711 Modifications prises en compte
+711 Modifications prises en compte!
 712 Fichier langue
 713 Etes-vous sûr de vouloir remplacer le fichier de langue
 714 Fichier de langue de référence
@@ -609,66 +611,67 @@
 720 Temps d'attente entre 2 cycles de télédéploiement
 721 Temps d'attente entre 2 fragments téléchargés
 722 Temps d'attente entre 2 périodes de télédéploiement
-723 Priorité maximum des paquets téléchargés<br>(Les paquets d'une priorité supérieure sont ignorés)
+723 Priorité maximum des paquets téléchargés<br>(paquets d'une priorité supérieure sont ignorés)
 724 Temps entre 2 prises de contacts entre l'agent et le serveur
 725 (en heure)
 726 URI des serveurs de redistribution ($IP$ et $NAME$ sont les valeurs génériques)
-727 Répertoire de destination des paquets.
+727 Répertoire de destination des paquets
 728 Inventaire
 729 ordinateurs
 730 heures
-731 Fonctionnalité de commit sur la base à chaque section d'inventaire.
+731 Fonctionnalité de "commit" sur la base à chaque section d'inventaire.
 732 milliseconde(s)
-733 Inactif
+733 inactif
 734 Fichiers inventaire
 735 Filtres
 736 Active la fonctionnalité de groupes de machines
 737 Nombre aléatoire compris entre 0 et la valeur définie (évite le calcul simultané de tous les groupes)
-738 Spécifie la validité d'un groupe (par défaut : calculé une fois par jour - voir la valeur précédente)739 Amélioration futur de la sécurité
-740 Validité du lock d'un ordinateur
-741 Configuration du moteur pour mettre à jour les sections d'inventaire en fonction du CHECKSUM (pour baisser la charge de DB backend )
-742 Faire que le moteur considère un inventaire comme une transaction (accès concurrentiel plus bas, meilleure utilisation du disque)
+738 Spécifie la validité d'un groupe (par défaut: calculé une fois par jour - voir la valeur précédente)
+739 Amélioration futur de la sécurité
+740 Validité du filtre d'un ordinateur
+741 Configuration du moteur pour mettre à jour les sections d'inventaire en fonction du "checksum" (pour baisser la charge de DB "backend")
+742 Faire que le moteur considère un inventaire comme une transaction (accès concurrentiel plus bas et meilleure utilisation du disque)
 743 Configuration du moteur pour une mise à jour différentielle des sections d'inventaire (au niveau des rangées). Diminue la charge du backend DB, augmente la charge du frontend
-744 N'accepter un inventaire que si une session est active (refus du /FORCE)
+744 N'accepter un inventaire que si une session est active (refus du /force)
 745 Indique quand le moteur nettoiera les structures en cache de l'inventaire
-746 Spécifie la différence minimale pour remplacer un agent ipdiscover
+746 Spécifie la différence minimale pour remplacer un agent IpDiscover
 747 Désactive la durée avant une première élection (non recommandé)
-748 Active les groupes pour ipdiscover (par exemple, vous souhaitez empêcher certains groupes d'être des agents ipdiscover)
-749 Utiliser avec ocsinventory-injector, active la fonctionnalité multi entités
+748 Active les groupes pour IpDiscover (par exemple, vous souhaitez empêcher certains groupes d'être des agents IpDiscover)
+749 Utiliser avec ocsinventory-injector. Activer la fonctionnalité multi entités
 750 Génère ou bien un fichier compressé, ou bien un fichier texte XML en clair
-751 Spécifie si vous souhaitez garder une trace de tous les inventaires entre une synchronisation avec un serveur de plus haut niveau
-752 Chemin vers le répertoire des fichiers ocs (les droits d'écriture doivent être activés)
+751 Spécifier si vous souhaitez garder une trace de tous les inventaires entre une synchronisation avec un serveur de plus haut niveau
+752 Chemin vers le répertoire des fichiers OCS (les droits d'écriture doivent être activés)
 753 Active la pile du filtre du prolog
-754 Autorise le système de filtre à modifier des choses "à la volée"
+754 Autoriser le système de filtre à modifier paramètres "à la volée"
 755 Active le filtre anti-flooding d'inventaire. Une même adresse IP ne peut envoyer un nouvel ordinateur qu'une seule fois dans la période
-756 Définition de la période pour INVENTORY_FILTER_FLOOD_IP
+756 Définition de la période pour "INVENTORY_FILTER_FLOOD_IP"
 757 Active la pile de filtre d'inventaire
-758 Spécifie si vous souhaitez suivre les paquets affectés à un groupe de niveau ordinateur
-759 Doit être supérieur ou égal à
+758 Spécifier si vous souhaitez suivre les paquets affectés à un groupe de niveau ordinateur
+759 doit être supérieur ou égal à
 760 Webservice
 761 Activer/désactiver le webservice
 762 Taille de la page de résultats (a des conséquences sur les performances)
 763 Fichiers d'inclusion de vos propres extensions
-764 Ces options ne sont pas modifiables par la GUI.<br>(modifier directement dans ocsinventory-server.conf)
+764 Ces options ne sont pas modifiables par la interface graphique.<br>(modifier directement dans ocsinventory-server.conf)
 765 Tous les logiciels
-766 AUCUN RESULTAT
-767 ATTENTION: RESULTATS AVEC FILTRE
+766 Aucun resultat!
+767 <b>Avertissement:</b> resultats avec filtre!
 768 Nombre d'enregistrement
 769 Transfert effectué
-770 MISE A JOUR DE
+770 Mise a jour de
 771 Cette catégorie existe déjà
 772 Le nom de la nouvelle catégorie ne peut être nul
 773 Vous devez sélectionner un nom de catégorie
 774 Vous essayez de faire un transfert de la catégorie vers la même catégorie
 775 Répertoire de création des paquets
-776 Répertoire de mise en cache des analyses d'ipdiscover
+776 Répertoire de mise en cache des analyses d'IpDiscover
 777 Durée de validité d'une session
-778 Nombre de WORKGROUP différents
+778 Workgroup différents
 779 TAG différents
 780 Sous-réseaux différents
 781 Machines ayant un paquet en cours de télédéploiement
 782 Machines ayant un paquet en erreur
-783 Nombre d'OS différents
+783 OS différents
 784 Agents différents
 785 Processeurs différents
 786 Résolutions différentes
@@ -678,14 +681,14 @@
 790 Machine avec RAM >=
 791 Machine avec RAM =<
 792 Machine avec RAM entre
-793 Machines en base
-794 Machines vues
-795 Machines ayant pris contact aujourd'hui
-796 Nombre d'inventaires aujourd'hui
-797 Machines absentes depuis plus de
-798 ACTIVITE
-799 MATERIEL
-800 DIVERS
+793 Machines dans la base de données
+794 Machines inventoriés
+795 Machines contactés aujourd'hui
+796 Machines inventoriés aujourd'hui
+797 Machines non inventoriés pour plus de
+798 Activite
+799 Materiel
+800 Divers
 801 Ne plus afficher cette donnée
 802 Afficher cette donnée
 803 Nombre de jours depuis que la machine n'a pas pris contact
@@ -694,8 +697,8 @@
 806 Taille RAM minimum
 807 Taille RAM maximum
 808 Répartition
-809 GROUPES STATIQUES
-810 GROUPES DYNAMIQUES
+809 Groupes statiques
+810 Groupes dynamiques
 811 Etes-vous sûr de vouloir modifier la visibilité du groupe
 812 Les logiciels à 0 sont présents en cache mais ne sont plus installés sur les machines.<br>Ils ne peuvent pas être mis dans une catégorie de dictionnaire
 813 Nombre disque dur avec taille restante >
@@ -706,7 +709,7 @@
 818 Sortir du groupe
 819 machine(s) ajoutée(s) au groupe
 820 Dernier contact
-821 MODIFICATION DE LA CONFIGURATION DU SERVEUR
+821 Modification de la configuration du serveur
 822 Personnaliser
 823 Par défaut
 824 Activation des logs de l'interface
@@ -715,102 +718,102 @@
 827 Adresse où se trouvent les fichiers INFO des paquets de télédéploiement à activer
 828 Suppression des machines dont l'inventaire est plus vieux de
 829 Répertoire de création des paquets de redistribution
-830 Adresse du serveur Ldap
-831 Port du serveur Ldap
-832 Nom de la base Ldap + dc
+830 Adresse du serveur LDAP
+831 Port du serveur LDAP
+832 Nom de la base LDAP + DC
 833 Nom du champ définissant le login
-834 Version LDAP_OPT_PROTOCOL_VERSION
+834 Version LDAP
 835 Ajouter un RSX
-836 Administrer les TYPES
+836 Administrer les types
 837 Vous n'avez pas accès à cette donnée
-838 Disque: Lettre de lecteur
-839 Disque: Type
-840 Disque: Format
-841 Disque: Capacité
-842 Disque: Espace libre
-843 Disque: Nom du volume
-844 Groupe: Id
-845 Groupe: Statique ?
-846 Logiciels: Société
-847 Logiciels: Nom
-848 Logiciels: Version
-849 Logiciels: Répertoire d'installation
-850 Logiciels: Commentaires
-851 Bios: Fabricant ordi
-852 Bios: Modèle
-853 Bios: Numéro de Série
-854 Bios: Type ordi
-855 Bios: Fabricant
-856 Bios: Version
-857 Bios: Date
-858 Moniteur: Fabricant
-859 Moniteur: Nom
-860 Moniteur: Description
-861 Moniteur: Type
-862 Moniteur: Numéro de série
-863 Réseaux: Description
-864 Réseaux: Type
-865 Réseaux: TypeMib
-866 Réseaux: Vitesse
-867 Réseaux: Adresse MAC
-868 Réseaux: Statuts
-869 Réseaux: Adresse IP
-870 Réseaux: Masque IP
-871 Réseaux: IP Sous-Réseaux
-872 Réseaux: IP Passerelle
+838 Disque: lettre de lecteur
+839 Disque: type
+840 Disque: format
+841 Disque: capacité
+842 Disque: espace libre
+843 Disque: nom du volume
+844 Groupe: ID
+845 Groupe: statique?
+846 Logiciel: société
+847 Logiciel: nom
+848 Logiciel: version
+849 Logiciel: répertoire d'installation
+850 Logiciel: commentaires
+851 Bios: fabricant ordi
+852 Bios: modèle
+853 Bios: numéro de Série
+854 Bios: type ordi
+855 Bios: fabricant
+856 Bios: version
+857 Bios: date
+858 Moniteur: fabricant
+859 Moniteur: nom
+860 Moniteur: description
+861 Moniteur: type
+862 Moniteur: numéro de série
+863 Réseaux: description
+864 Réseaux: type
+865 Réseaux: typemib
+866 Réseaux: vitesse
+867 Réseaux: adresse MAC
+868 Réseaux: statuts
+869 Réseaux: adresse IP
+870 Réseaux: masque IP
+871 Réseaux: IP sous-réseaux
+872 Réseaux: IP passerelle
 873 Réseaux: IP DHCP
-874 Clé de registre: Nom
-875 Clé de registre: Valeur
-876 DESaffectation simple GROUPE REDISTRIBUTION
-877 DES MACHINES N'ONT PAS ETE AJOUTEES AU GROUPE CAR:
-878 Rappel: une machine ne peut faire partie que d'un seul groupe de redistribution
-879 GROUPE REMPLACE
-880 GROUPE CREE
-881 machines ajoutées
-882 machines supprimées du groupe
+874 Clé de registre: nom
+875 Clé de registre: valeur
+876 Desaffectation simple groupe redistribution
+877 Des machines n'ont pas ete ajoutees au groupe car:
+878 <b>Rappel:</b> une machine ne peut faire partie que d'un seul groupe de redistribution
+879 Groupe remplace!
+880 Groupe cree!
+881 Machines ajoutées!
+882 Machines supprimées du groupe
 883 Restreindre l'affichage
-884 ATTENTION: Visualisation AVEC FILTRE
+884 <b>Avertissement:</b> visualisation avec filtre!
 885 inconnu
-886 DESaffectation simple
+886 Desaffectation simple
 887 Il est aussi possible que ce paquet ne soit pas affecté sur leur serveur de redistribution
 888 Suppression
-889 connecté en tant que
+889 Connecté en tant que
 890 L'interface est actuellement verrouillée sur une recherche multicritère
-891 DEVERROUILLER l'interface
+891 Deverrouiller l'interface
 892 se connecter avec un autre compte
-893 PAS DE TAG AFFECTE A VOTRE PROFIL
-894 PAS DE NIVEAU DE DROITS DEFINI POUR VOTRE PROFIL
+893 Pas de TAG affecte a votre profil
+894 Pas de niveau de droits defini pour votre profil
 895 Modification d'un TAG
-898 Ajouter une annotation
+898 Ajouter une note
 899 Rédacteur
 900 Etes-vous sûr de vouloir supprimer la sélection?
 901 Action sur le résultat de la requête
 902 Action sur le résultat de la sélection
 903 Le champ d'explication est obligatoire
 904 Réaffectation du paquet
-905 Explication des actions effectuées <br>sur le poste pour permettre <br>l'affectation du paquet
+905 Explication des actions effectuées<br>sur le poste pour permettre<br>l'affectation du paquet
 906 Suppression du télédéploiement du paquet
 907 Explication de la suppression du paquet<br>sur cette machine
-908 Infos du terminal mobile
-909 MODIFICATION NON EFFECTUEE: NOUVEAU PROFIL INCORRECT
+908 Informations du terminal mobile
+909 Modification non effectuee. Nouveau profil incorrect
 910 Valider
 911 Changement de profil de
 912 Exporter la liste des machines ayant ces logiciels
-913 Nombre d'interfaces réseau non inventoriées
+913 Interfaces réseau non inventoriées
 914 Nombre d'agent n'envoyant plus d'inventaire depuis au moins
 915 messages
 916 La valeur doit être supérieur à
-917 valeur de FREQUENCY
-918 Différentiel entre LASTDATE et LASTCOME
+917 valeur de frequency
+918 Différentiel entre lastdate et lastcome
 919 Etes-vous sûr de vouloir supprimer ce message
-920 ERREUR, le fichier demandé n'existe pas.
+920 <b>Erreur:</b> le fichier demandé n'existe pas!
 921 Supprimer cette catégorie
 922 Pour Fusionner, il faut au moins sélectionner 2 machines
 923 Vous n'avez aucun ordinateur en compte
-924 REQUETE D'EXTRACTION NON CONFORME!
-925 Fonctionnalité FUSER
-926 Login Fuser:
-927 LE CACHE N'EST PAS REGENERE PAR CETTE ACTION
+924 Requete d'extraction non conforme!
+925 Fonctionnalité fuser
+926 Login fuser:
+927 Le cache n'est pas regenere par cette action
 928 Visualisation des logs
 929 la gestion des sous-réseaux n'est pas faite en local.
 930 Vous ne pouvez donc pas ajouter/modifier/supprimer des sous-réseaux
@@ -824,7 +827,7 @@
 938 Nouveau type
 939 Les machines présentes dans le groupe
 940 Toutes les machines ayant ce paquet
-941 AFFICHAGE DES STATISTIQUES SUR
+941 Affichage des statistiques sur
 942 Vous devez mettre un commentaire pour ce périphérique
 943 Vous devez choisir le type de périphérique
 944 Donnée entrée par
@@ -832,56 +835,56 @@
 946 Ajout d'un nouveau périphérique
 947 Liste des périphériques non identifiés
 948 Liste des périphériques identifiés
-949 Id de la machine
-950 NOM FICHIER
-951 FICHIER CREE LE
-952 FICHIER MODIFIE LE
-953 TAILLE
-954 Une perte de SESSION a eu lieu
-955 PAS DE SYSTEME TROUVE EN BASE
+949 ID de la machine
+950 Nom fichier
+951 Fichier creé le
+952 Fichier modifié le
+953 Taille
+954 Une perte de session a eu lieu
+955 Pas de systeme trouve en base
 956 Toutes les erreurs
-957 Tous les SUCCESS
-958 PROBLEME DE VALEUR DE TELEDEPLOIEMENT
-959 TROP DE LOGICIELS REMONTES. SOYEZ PLUS PRECIS DANS LA RECHERCHE
-960 AUCUN LOGICIEL CORRESPONDANT A LA RECHERCHE
-961 LISTE DE
+957 Tous les succès
+958 Probleme de valeur de teledeploiement
+959 Trop de logiciels remontes. Soyez plus precis dans la recherche
+960 Aucun logiciel correspondant a la recherche
+961 Liste de
 962 (une ',' entre chaque)
-963 DIFFERENT LISTE DE
+963 Different liste de
 964 Nom de la partition
 965 Ecran
 966 Agent
-967 APPARTIENT
-968 N'APPARTIENT PAS
+967 Appartient
+968 N'appartient pas
 969 Historique des paquets
 970 Paquets
-971 SUPPRESSION DES MACHINES DU GROUPE
+971 Suppression des machines du groupe
 972 Les machines ont bien été enlevées du groupe
-973 AJOUT DES MACHINES AU GROUPE
+973 Ajout des machines au groupe
 974 machines insérées dans le cache
 975 Ajouter au groupe
-976 LOCK de L'INTERFACE SUR LE RESULTAT DE LA REQUETE
-977 LOCK
-978 Vous aller verrouiller toute l'interface sur les résultats de cette recherche multicritère
-979 Pour revenir à un état normal, vous cliquerez sur l'icône <img src='image/cadena_op.png' > se trouvant en haut à droite de l'interface
+976 Filtre de l'interface sur le resultat de la requete
+977 Filtre
+978 Vous allez verrouiller toute l'interface sur les résultats de cette recherche multicritère
+979 Pour revenir à l'état normal, vous cliquez sur l'icône <img src='image/cadena_op.png'> se trouvant en haut à droite de l'interface
 980 Paquets sur les machines
 981 Paquets sur les groupes de redistribution
-982 AUCUNE REGLE D'AFFECTATION N'EXISTE. PAS DE REDISTRIBUTION POSSIBLE.
+982 Aucune regle d'affectation n'existe. Pas de redistribution possible.
 983 Vous devez choisir sur quel type doit s'effectuer les modifications
 984 Modifications
-985 SUPPRESSION DE MACHINES
-986 SUPPRIMER LES MACHINES POUR
-987 Cette clé de registre existe déjà
-988 TOUS LES CHAMPS SONT OBLIGATOIRES
-989 LES DONNEES N'EXISTENT PAS. LES HEURES DES ETATS NE SONT PAS PRESENTES EN BASE POUR CE PAQUET
+985 Suppression de machines
+986 Supprimer les machines pour
+987 Cette clé de registre existe déjà!
+988 Tous les champs sont obligatoires
+989 Les donnees n'existent pas. Les heures des etats ne sont pas presentes en base pour ce paquet
 990 Paquets créés manuellement
 991 Paquets créés automatiquement
 992 Estimation du temps de télédéploiement
 993 Les champs en rouge sont en erreur
-994 PDA/SMARTPHONE
+994 PDA/smartphone
 995 Login
-996 Nom
+996 Nom de famille
 997 ID utilisateur obligatoire
-998 choisissez un profil valide
+998 Choisissez un profil valide
 999 Cet ID utilisateur existe déjà
 1000 Notifié
 1001 Les champs en rouge sont en erreur!
@@ -893,33 +896,33 @@
 1007 Le répertoire
 1008 Utilisation sur ce paquet de la redistribution
 1009 Chemin sur le serveur
-1010 NORMAL
-1011 DEBUG
-1012 LANGUE
-1013 MAINTENANCE
+1010 Normal
+1011 Debug
+1012 Langue
+1013 Maintenance
 1014 Passer en mode
 1015 Mode de fonctionnement
-1016 Identifiant ROOT
-1017 Mot de passe ROOT
-1018 (Laisser à vide pour une connexion anonyme)
-1019 Lock du résultat
+1016 Login root
+1017 Mot de passe root
+1018 (laisser à vide pour une connexion anonyme)
+1019 Filtre du résultat
 1020 Libellé du TAG
 1021 Gestion des télédéploiements
 1022 Gestion des TAG
-1023 paquets affectés dans l'état
+1023 Paquets affectés dans l'état
 1024 vont être supprimés
 1025 Désaffecter
-1026 paquets supprimés sur les machines
+1026 Paquets supprimés sur les machines
 1027 Catégories
 1028 Nouveau
 1029 Ignoré
 1030 Inchangé
 1031 Demandes
 1032 Activer le workflow pour le télédéploiement
-1033 Inf. demandeur
-1034 Inf. générales Paquet
-1035 Inf. techniques Paquet
-1036 Inf. validation
+1033 Information demandeur
+1034 Information générales paquet
+1035 Information techniques paquet
+1036 Information validation
 1037 Nom du paquet
 1038 Demandeur
 1039 Priorité
@@ -930,18 +933,18 @@
 1044 Par liste
 1045 Par visuel
 1046 Statut
-1047 INFO
+1047 Information
 1048 Ajouter un fichier
-1049 ACTION INTERDITE
+1049 Action interdite
 1050 Recherche logiciels
 1051 Recherche
 1052 Historique
 1053 Demande modifiée
 1054 Demande effectuée
-1055 Votre adresse mail n'est pas valide
+1055 Votre adresse e-mail n'est pas valide
 1056 Contactez votre administrateur OCS-NG
-1057 Impossible de se connecter au serveur de mail
-1058 Aucun email n'est valide
+1057 Impossible de se connecter au serveur de e-mail
+1058 Aucun e-mail n'est valide
 1059 Données existantes
 1060 Nouvelle donnée
 1061 Onglet
@@ -952,14 +955,14 @@
 1066 Lié à un statut
 1067 Ce nom de champ est déjà utilisé
 1068 Le nom du champ ne peut pas être vide
-1069 Ajout de la valeur effectuée
-1070 Nouveau Champ
+1069 Valeur ajoutée!
+1070 Nouveau champ
 1071 Type de champ
 1072 Suivi des demandes
 1073 Faire une demande
-1074 La fonctionnalité 'Workflow' n'est pas activée.
+1074 La fonctionnalité workflow n'est pas activée.
 1075 Veuillez activer la fonctionnalité pour l'utiliser
-1076 ERROR: STATUS RECHERCHE NON DEFINI
+1076 <b>Erreur:</b> status recherche non defini!
 1077 Niveau de création de paquet
 1078 Niveau de test
 1079 Niveau du périmètre restreint
@@ -970,15 +973,15 @@
 1084 Nom du groupe de test
 1085 Nom du groupe du périmètre restreint
 1086 Libellé du TAG de définition du paramètre
-1087 Valeur du tag de test
-1088 Valeur du tag du périmètre restreint
+1087 Valeur du TAG de test
+1088 Valeur du TAG du périmètre restreint
 1089 Aucun statut n'est actif. Commencez par en activer un.
 1090 a modifié la demande n°
 1091 Une nouvelle demande vient d'être postée
 1092 a posté une nouvelle demande
 1093 La base de données est incomplète
-1094 Veuillez rejouer l'installation complète de la base
-1095 Admin statut
+1094 Veuillez rejouer l'installation complète de la base de données
+1095 Administrateur de statut
 1096 Liste des champs
 1097 Liste des onglets
 1098 Nom du champ
@@ -988,7 +991,7 @@
 1102 Statut actif
 1103 ID du statut
 1104 Niveau
-1105 La fonctionnalité de Workflow pour le télédéploiement est activée
+1105 La fonctionnalité de workflow pour le télédéploiement est activée
 1106 Il n'est possible de créer un paquet que si une demande préalable existe
 1107 Et qu'elle soit en statut de création de paquet
 1108 Configuration LDAP
@@ -1004,7 +1007,7 @@
 1118 Editer
 1119 Sélectionner
 1120 Quantité
-1121 Mise à jour effectuée
+1121 Mise à jour effectuée!
 1122 Wiki
 1123 IRC
 1124 Forums
@@ -1012,71 +1015,71 @@
 1126 Date de la note
 1127 Auteur de la note
 1128 Note
-1129 PAQUET SUPPRIME
-1130 EDITION LANGUE
+1129 Paquet supprimé
+1130 Édition langue
 1131 Mot
 1132 ID mot
 1133 Nouveau libellé
-1134 Pas de donnée Ipdiscover
+1134 Pas de donnée IpDiscover
 1135 machine(s) sont déjà présentes dans le groupe de redistribution
-1136 Snmp
-1137 Activer/désactiver le snmp
+1136 SNMP
+1137 Activer/désactiver le SNMP
 1138 Afficher tous mes réseaux
 1139 Administrer
 1140 Administrer les sous-réseaux
 1141 Sous-réseau ajouté
 1142 Ajouter un sous-réseau à blacklister
 1143 Masque sous-réseau
-1144 Adresse MAC non valide. (format XX.XX.XX.XX.XX.XX)
+1144 Adresse MAC non valide. (doit être XX.XX.XX.XX.XX.XX)
 1145 La valeur doit être comprise entre
 1146 Administrer les profils
 1147 Vous ne pourrez pas le modifier.
-1148 <b>ATTENTION:</b> Aucune sauvegarde automatique des fichiers de configuration ne sera possible
+1148 <b>Avertissement:</b> aucune sauvegarde automatique des fichiers de configuration ne sera possible!
 1149 Nom du nouveau profil
 1150 Profil de référence
 1151 Libellé du profil
-1152 ATTENTION: la suppression des profils peut entraîner une instabilité de OCS-NG
+1152 <b>Avertissement:</b> la suppression des profils peut entraîner une instabilité de OCS-NG!
 1153 Nom du profil
 1154 Sur les machines
 1155 Sur le workflow de télédéploiement
-1156 Administrer le workflow de téléploiement
+1156 Administrer le workflow de télédéploiement
 1157 Sur les champs du workflow de télédéploiement
 1158 Sur l'activation des paquets
 1159 Sur les adresses MAC
 1160 Sur les numéros de série
-1161 Sur les sous-réseaux de l'ipdiscover
-1162 Administrer la télédiff
+1161 Sur les sous-réseaux de l'IpDiscover
+1162 Administrer la télédéploiement
 1163 Modifier la configuration
 1164 Administrer les groupes
 1165 Administrer la console
-1166 Voir les messages d'alerte de la GUI
-1167 Administrer les accountinfos
-1168 Peut changer les accountinfos des machines
+1166 Voir les messages d'alerte dans l'interface graphique
+1167 Administrer les informations de comptes
+1168 Peut changer les informations de comptes des machines
 1169 Peut changer son groupe d'appartenance
 1170 Administrer les profils
 1171 Administrer les groupes des profils
-1172 Administrer l'ipdiscover
+1172 Administrer l'IpDiscover
 1173 Information du profil
 1174 Pages utilisateur
 1175 Restrictions
-1176 Droits Blacklist
+1176 Droits blacklist
 1177 Droits configuration
 1178 Ce champ
 1179 est une variable. Il ne peut contenir de caractères spéciaux.
 1180 ne peut pas être vide
-1181 Fonctionnalité Serveur de redistribution
-1182 Vous ne pouvez pas administrer les règles de redistribution, la fonctionnalité est désactivée
+1181 Fonctionnalité serveur de redistribution
+1182 Vous ne pouvez pas administrer les règles de redistribution. La fonctionnalité est désactivée
 1183 Liste des paquets à créer
-1184 Clé ajoutée
-1185 Clé modifiée
-1186 Vos données ont été mises à jour
+1184 Clé ajoutée!
+1185 Clé modifiée!
+1186 Vos données ont été mises à jour!
 1187 En cours de configuration
-1188 Ce groupe est déclaré comme un périmètre de TEST
-1189 Ce groupe est déclaré comme un périmètre RESTREINT
+1188 Ce groupe est déclaré comme un périmètre de test
+1189 Ce groupe est déclaré comme un périmètre restreint
 1190 Vous ne pouvez affecter des paquets que de niveau supérieur à
-1191 Rappel: la configuration du workflow de télédéploiement est actuellement sur
-1192 Groupe pouvant recevoir des paquets de TEST
-1193 Groupe pouvant recevoir des paquets de périmètre RESTREINT
+1191 <b>Rappel:</b> la configuration du workflow de télédéploiement est actuellement sur
+1192 Groupe pouvant recevoir des paquets de test
+1193 Groupe pouvant recevoir des paquets de périmètre restreint
 1194 Seuls les paquets de niveau supérieur à
 1195 peuvent être affectés
 1196 Profil
@@ -1085,20 +1088,20 @@
 1199 Version SNMP
 1200 Valeur modifiée
 1201 Ecran
-1202 Linux (TOUS)
-1203 Windows (TOUS)
+1202 Linux (tous)
+1203 Windows (tous)
 1204 IpDiscover
 1205 Administrer les communautés SNMP
 1206 Répertoire du fichier des communautés SNMP
-1207 Ajouter une communauté
-1208 Communauté ajoutée
-1209 Communauté modifiée
-1210 Account info:
+1207 Ajouter une communauté SNMP
+1208 Communauté ajoutée!
+1209 Communauté modifiée!
+1210 Information de compte:
 1211 URL du fichier des communautés SNMP
 1212 Communauté supprimée
 1213 Séparateur des fichiers d'export
-1214 Configurer le moteur pour mettre à jour l'inventaire snmp en se basant sur la table snmp_laststate (charge inférieure backend DB)
-1215 Serveur Blade
+1214 Configurer le moteur pour mettre à jour l'inventaire SNMP en se basant sur la tableau "snmp_laststate" (charge inférieure backend DB)
+1215 Serveur blade
 1216 Pare-feu
 1217 Répartiteur de charge
 1218 Switch(s)
@@ -1111,20 +1114,20 @@
 1225 Capacité maximale
 1226 Couleur
 1227 Contact
-1228 Identifiant SNMP
+1228 Dispositif SNMP
 1229 Firmware
 1230 Nom du volume
-1231 le format de fichier doit être en ZIP
-1232 le format de fichier doit être en TAR.GZ
-1233 Nom de la base donnée
+1231 Le format de fichier doit être en ZIP
+1232 Le format de fichier doit être en TAR.GZ
+1233 Nom de la base de données
 1234 La description ne peut pas être vide
 1235 Référence
 1236 Version du logiciel
 1237 Version du firmware
 1238 Date d'installation
 1239 MHz
-1240 Mo
-1241 Nombre de périphériques SNMP remontés
+1240 MB
+1241 Périphériques SNMP remontés
 1242 d/m/y
 1243 Seuls les fichiers ocsagent.exe, OCS-NG-Windows-Agent-Setup.exe et ocspackage.exe peuvent être envoyés
 1244 Le fichier ne peut pas être vide
@@ -1132,47 +1135,47 @@
 1246 Affecter à nouveau
 1247 Architecture
 1248 Répertoire
-1249 Activation du cache des tableaux (permet de moins solliciter la base MySQL)
+1249 Activation du cache des tableaux (permet moins de sollicitations à la base de données MySQL)
 1250 Vitesse de télédéploiement
 1251 Statistiques
-1252 Répertoire des fichiers de conf profils
-1253 Répertoire des sauvegardes des fichiers de conf profils
+1252 Répertoire des fichiers de configuration profils
+1253 Répertoire des sauvegardes des fichiers de configuration profils
 1254 Répertoire des logs des scripts
-1255 Nombre de Connexion par jour
+1255 Nombre de connexion par jour
 1256 Nombre d'erreurs de connexion par jour
-1257 Utilisation du flash dans la GUI
-1258 Entrée Manuelle
+1257 Utilisation du flash dans la interface graphique
+1258 Entrée manuelle
 1259 Sur une semaine
 1260 Sur un mois
 1261 Vider le cache
 1262 Aucun module activé pour votre profil
-1263 ALERTE SECURITE!
+1263 Alerte securite!
 1264 Suite
 1265 Activation des tables de cache
-1266 Machines Virtuelles
-1267 Type de Machine Virtuelle
-1268 Uuid
+1266 Machines virtuelles
+1267 Type de machine virtuelle
+1268 UUID
 1269 Machine hébergée par
 1270 DDMMYYYY
 1271 Liste des machines du sous-réseau
-1272 Supprimer ses machines
+1272 Supprimer ces machines
 1273 Vous n'avez pas le droit de supprimer une machine
 1274 Profil mis à jour
 1275 Les profils ne peuvent être supprimés.
 1276 Profil créé
 1277 Profil par défaut (vide pour aucun)
-1278 Vous n'êtes pas autorisé à vous connecter
+1278 Vous n'êtes pas autorisé à vous connecter.
 1279 WOL
-1280 Wake On Lan
-1281 Sur le Wake On Lan
-1282 Ordre de Wake On Lan envoyé
-1283 Exécuter un Wake On Lan sur cette machine
-1292 Utiliser les options avancées de téléploiement
+1280 Wake on lan
+1281 Sur le "wake on lan"
+1282 Ordre de "wake on lan" envoyé
+1283 Exécuter un "wake on lan" sur cette machine
+1292 Utiliser les options avancées de télédéploiement
 1293 Forcer le télédéploiement
 1294 Heure d'installation
 1295 Date d'installation
 1296 Offres commerciales
-1297 Numéro d'identification
+1297 Numéro d'identification SNMP
 1298 Gestion des QRCode
 1299 QRCode
 1300 Vérifier QRCode
@@ -1189,20 +1192,20 @@
 1311 Redémarrage
 1312 Taille transfert du bus
 1313 Taille adressage des données
-1314 Nombre de coeurs logiques
+1314 Nombre de CPUs logiques
 1315 Fréquence de fonctionnement
 1316 Type de socket
 1317 Nombre de coeurs
-1318 Cache L2
+1318 Taille du cache L2
 1319 Tension
-1320 Utiliser , pour séparer les informations
+1320 Utiliser "," pour séparer les informations
 1321 Aucun port WOL défini
-1322 Impossible d'ouvrir la socket pour le WOL
+1322 Impossible d'ouvrir le socket pour le WOL
 1323 Serveur de partage imprimante
 1324 Partage imprimante sur serveur
 1325 Résolution format horizontal/vertical
 1326 Partagée
-1327 Local/Réseaux
+1327 Local/réseaux
 1328 Gestion
 1329 Administration
 1330 Matériel
@@ -1216,7 +1219,7 @@
 1338 Afficher _MENU_ résultats
 1339 Chargement en cours...
 1340 Traitement en cours...
-1341 Rechercher&nbsp;:&nbsp;
+1341 Rechercher:
 1342 Aucun résultat à afficher
 1343 Premier
 1344 Dernier
@@ -1224,14 +1227,14 @@
 1346 Précédent
 1347 activer pour trier la colonne par ordre croissant
 1348 activer pour trier la colonne par ordre décroissant
-1349 Afficher / Cacher
+1349 Afficher/cacher
 1350 .
 1351 ,
 1352 Contenu de la requête invalide
 1353 Accès non autorisé
 1354 Les droits ne sont pas suffisants pour accéder à la ressource demandée
 1355 Page non-trouvée
-1356 L'URL demandé est trop long, essayez de supprimer les cookies d'OCS ( vous serez déconnecté )
+1356 L'URL demandé est trop long. Essayez de supprimer les cookies d'OCS (vous serez déconnecté)
 1357 Erreur interne du serveur
 1358 Le service n'est pas disponible
 1359 Utilisateur déconnecté
@@ -1245,16 +1248,16 @@
 1367 Réseau
 1368 CPU
 1369 Version de PHP
-1370 Serveur Web
+1370 Serveur WEB
 1371 Serveur SQL
 1372 Kernel
 1373 Distribution
-1374 Accéder au site
-1375 Anciens Forums
+1374 Accéder au site WEB
+1375 Anciens forums
 1376 Q&amp;R
 1377 Questions et réponses
 1378 RAM disponible
-1379 RAM totale
+1379 RAM installé
 1380 Afficher les colonnes par défaut
 1381 Actions
 1382 Numéro de série de la carte mère
@@ -1281,23 +1284,22 @@
 1403 Créer un utilisateur
 1404 Des erreurs ont été rencontrées durant la validation de ce profil
 1405 Le profil a été créé avec succès
-1406 Une erreur s'est produite durant la création du profil, veuillez vérifier le système de fichiers ou contacter un administrateur
+1406 Une erreur s'est produite durant la création du profil. Veuillez vérifier le système de fichiers ou contacter un administrateur
 1407 Impossible d'écrire dans le fichier du profil
 1408 Le profil a été mis à jour avec succès
-1409 Une erreur s'est produite durant la modification du profil, veuillez vérifier le système de fichiers ou contacter un administrateur
+1409 Une erreur s'est produite durant la modification du profil. Veuillez vérifier le système de fichiers ou contacter un administrateur
 1410 Utilisateurs
 1411 Nom affiché
 1412 Modifier profil
 1413 Nouveau label
 1414 Détails de la machine
-
-2000 * SETUP voices 2000-2200 * (2000-2029 Common voices *** 2030-2200 Setup voices)
-2001 ERREUR:
-2002 ERREUR: ligne
-2003 ERREUR MySQL:
-2004 (Utilisation d'un nouveau compte OCS)
+2000 * Setup voices 2000-2200 * (2000-2029 common voices *** 2030-2200 setup voices)
+2001 <b>Erreur:</b>
+2002 <b>Erreur:</b> ligne!
+2003 <b>Erreur MySQL:</b>
+2004 (utilisation d'un nouveau compte OCS)
 2005 Sous-réseaux
-2006 AVERTISSEMENT:
+2006 <b>Avertissement:</b>
 2007 Compte
 2008 Erreur
 2009 a échoué
@@ -1315,96 +1317,94 @@
 2021 Le répertoire de LOGS n'est pas ouvert en écriture
 2022 Vous ne pouvez envoyer un fichier d'une taille supérieur à
 2023 Supprimez le.
-2024 Le compte/mot de passe par défaut est actif sur votre base de donnée:
-2025 Changer le mot de passe du compte 'ocs' dans MySQL
-2026 Le compte/mot de passe par défaut de l'interface WEB est actif
-2027 Changer le mot de passe du compte 'admin' dans l'interface web
+2024 Le login/mot de passe par défaut est actif sur votre base de donnée:
+2025 Changer le mot de passe du compte OCS dans MySQL
+2026 Le login/mot de passe par défaut de l'interface WEB est actif
+2027 Changer le mot de passe du compte "admin" dans l'interface WEB
 2028 Clé d'authentification
-2029 Le répertoire config n'est pas disponible en écriture
-
-
-2030 Installation d'OCS-NG Inventory
-2031 version actuellement installée
+2029 Le répertoire configuration n'est pas disponible en écriture
+2030 Installation d'OCS-NG inventory
+2031 Version actuellement installée
 2032 est inférieur à cette version
 2033 Installation automatique lancée.
 2034 Le fichier de configuration de BDD n'est pas valide. Installation automatique lancée
-2035 ERREUR: Les sessions pour PHP ne sont pas installées correctement. <br> Essayez d'installer le paquet php-session.
-2036 AVERTISSEMENT: XML pour PHP n'est pas installé correctement, vous ne serez pas en mesure d'utiliser ipdiscover-util.
-2037 ERREUR: MySQL pour PHP n'est pas installé correctement. <br> Essayez d'installer MySQL pour PHP paquet (Debian: php5-mysql)
-2038 AVERTISSEMENT: La librairie GD de PHP n'est pas installée correctement. <br> Les graphiques ne seront utilisables qu'en flash  <br> Pour corriger cela, essayez en décommentant extension = php_gd2.dll (Windows) en supprimant le point-virgule dans le fichier php.ini, ou essayez d'installer le paquet php5-gd (Linux).
-2039 AVERTISSEMENT: OpenSSL pour PHP n'est pas installé correctement. <br> Certaines fonctionnalités de déploiement automatique ne sera pas disponible <br> Essayez en décommentant extension = php_openssl.dll (Windows) en supprimant le point-virgule dans le fichier php.ini, ou essayez d'installer le paquet php-openssl (Linux).
-2040 AVERTISSEMENT: Vous ne serez pas en mesure de construire un paquet de déploiement d'une taille plus grande que
-2041 Vous devez modifier <font color="red">post_max_size</font> et <font color="red">upload_max_filesize</font> dans la configuration du vhost, pour augmenter cette limite.
-2042 AVERTISSEMENT: votre mot de passe root par défaut est défini sur votre serveur MySQL. Changez-le dès que possible. (Mot de passe root => vide)
-2043 AVERTISSEMENT: L'utilisateur que vous avez tapé ne semble pas être root <br> Si vous rencontrez un problème avec l'insertion des fichiers, essayez de définir la valeur de <font color="red">max_allowed_packet</font> de MySQL à au moins 2 Mo sur votre serveur le fichier de configuration.
+2035 <b>Erreur:</b> les sessions pour PHP ne sont pas installées correctement.<br>Essayez d'installer le paquet php-session!
+2036 <b>Avertissement:</b> XML pour PHP n'est pas installé correctement.<br>Vous ne serez pas en mesure d'utiliser ipdiscover-util!
+2037 <b>Erreur:</b> MySQL pour PHP n'est pas installé correctement.<br>Essayez d'installer MySQL pour PHP paquet (Debian: php5-mysql)!
+2038 <b>Avertissement:</b> la librairie GD de PHP n'est pas installée correctement.<br>Les graphiques ne seront utilisables qu'en flash<br>Pour corriger cela, essayez en décommentant "extension=php_gd2.dll" (Windows) en supprimant le point-virgule dans le fichier php.ini, ou essayez d'installer le paquet php5-gd (Linux)!
+2039 <b>Avertissement:</b> OpenSSL pour PHP n'est pas installé correctement.<br>Certaines fonctionnalités de déploiement automatique ne sera pas disponible<br>Essayez en décommentant "extension=php_openssl.dll" (Windows) en supprimant le point-virgule dans le fichier php.ini, ou essayez d'installer le paquet php-openssl (Linux)!
+2040 <b>Avertissement:</b> vous ne serez pas en mesure de construire un paquet de déploiement d'une taille plus grande que
+2041 Vous devez modifier <font color="red">"post_max_size"</font> et <font color="red">"upload_max_filesize"</font> dans la configuration du vhost, pour augmenter cette limite.
+2042 <b>Avertissement:</b> votre mot de passe root par défaut est défini sur votre serveur MySQL. Changez-le dès que possible (mot de passe root => vide)!
+2043 <b>Avertissement:</b> l'utilisateur que vous avez tapé ne semble pas être root<br>Si vous rencontrez un problème avec l'insertion des fichiers, essayez de définir la valeur de <font color="red">"max_allowed_packet"</font> de MySQL à au moins 2 Mo sur votre serveur le fichier de configuration!
 2044 Label ajouté
-2045 Label pas encore ajouté (Au lancement du client, aucune demande de TAG ne sera faite)
-2046 ERREUR: problème d'authentification MySQL.
-2047 Vous devez ajouter les "old-passwords" dans votre fichier de configuration MySQL (my.ini). Puis redémarrer MySQL, et relancez install.php
-2050 Installation terminée, vous pouvez vous connecter avec le login = admin et pass = admin
+2045 Label pas encore ajouté (au lancement du client, aucune demande de TAG ne sera faite)
+2046 <b>Erreur:</b> problème d'authentification MySQL!
+2047 Vous devez ajouter les "old-passwords" dans votre fichier de configuration MySQL (my.ini). Puis redémarrer MySQL et relancez install.php
+2050 Installation terminée. Vous pouvez vous connecter avec le login = admin et pass = admin.
 2051 Cliquez ici pour entrer dans l'interface OCS-NG
-2052 ERREUR: impossible d'écrire dans le répertoire (dans dbconfig.inc.php), veuillez définir les droits nécessaires pour installer ocsinventory (vous devez ajouter les droits d'écriture, et relancer l'installation)
-2053 Patientez, mettre à jour la base de données peut prendre jusqu'à 30 minutes ...
-2054 failed, KEY was too long<br>You need to redo this query later or you will experience severe performance issues.
+2052 <b>Erreur:</b> impossible d'écrire dans le répertoire (dans dbconfig.inc.php). Veuillez définir les droits nécessaires pour installer ocsinventory (vous devez ajouter les droits d'écriture et relancer l'installation!
+2053 Patientez. Mettre à jour la base de données peut prendre jusqu'à 30 minutes...
+2054 Échoué. La clé était trop longue <br> Vous devez refaire cette requête plus tard ou vous rencontrerez des problèmes de performances sévères.
 2055 Base de données générée
-2056 Fichier de config MySQL correctement écrit
-2057 mise à jour de la base de données existante
-2058 contrôle du moteur de base de données ...
-2059 ERREUR: requête de mise à jour a échoué
-2060 ERREUR: requête SHOW TABLE STATUS a échoué
-2061 ERROR: InnoDB conversion failed, install InnoDB  MySQL engine support on your server<br>or you will experience severe performance issues.<br>(Try to uncomment skip-innodb in your MySQL config file.)<br>Reinstall when corrected.
-2062 ERROR: HEAP conversion failed, install HEAP MySQL engine support on your server<br>or you will experience severe performance issues.
+2056 Fichier de configuration MySQL correctement écrit
+2057 Mise à jour de la base de données existante
+2058 Vérification du moteur de base de données...
+2059 <b>Erreur:</b> requête de mise à jour a échoué!
+2060 <b>Erreur:</b> requête "show table status" a échoué!
+2061 <b>Erreur:</b> La conversion InnoDB a échoué. Installez le support du moteur MySQL InnoDB sur votre serveur<br>ou vous rencontrerez de graves problèmes de performances. Essayez de décommenter "skip-innodb" dans votre fichier de configuration MySQL.<br>Réinstaller après correction!
+2062 <b>Erreur:</b> Conversion HEAP échoué, installer le support de moteur MySQL HEAP sur votre serveur ou vous rencontrerez des problèmes de performances sévères!
 2063 Moteur de base mis à jour
-2064 table(s) modifiée(s)
-2065 ERREUR: Le programme d'installation terminée en erreur, relancez install.php une fois que les problèmes sont corrigés
-2066 AVERTISSEMENT: le répertoire "files" est manquants, il est impossible d'importer
+2064 tableau(s) modifiée(s)
+2065 <b>Erreur:</b> le programme d'installation terminé en erreur. Relancer le install.php une fois que les problèmes sont corrigés!
+2066 <b>Avertissement:</b> le répertoire "files" est manquants. Il est impossible d'importer!
 2067 dès qu'il
-2068 n'a pas été inséré. Vous devez définir la valeur de max_allowed_packet MySQL pour au moins 2 Mo
-2070 missing, if you do not reinstall the DEPLOY feature won't be available
-2071 AVERTISSEMENT: Un ou plusieurs fichiers ont été déjà insérés
+2068 n'a pas été inséré. Vous devez définir la valeur de "max_allowed_packet" du MySQL comme au moins 2 Mo
+2070 manquant. Si vous ne réinstallez pas, la fonctionnalité de déploiement ne sera pas disponible
+2071 <b>Avertissement:</b> un ou plusieurs fichiers ont été déjà insérés!
 2072 les fichiers de déploiement ont été insérés
-2073 Table 'files' tronquée
-2074 Table 'files' était vide
+2073 Tableau "files" tronquée
+2074 Tableau "files" était vide
 2076 Pas de fichier subnet.csv à importer
 2077 Insertion des réseaux de subnet.csv
-2078 ERREUR: Impossible d'insérer le réseau
+2078 <b>Erreur:</b> impossible d'insérer le réseau!
 2079 dans le tableau de sous-réseau, l'erreur
-2080 AVERTISSEMENT: Réseau
-2081 n'a pas été inséré (ip valide ou un masque
-2082 Network netid computing. Please wait...
-2083 ERREUR: Impossible de mettre à jour netid
-2084 netid réseau a été calculé
+2080 <b>Avertissement:</b> réseau!
+2081 n'a pas été inséré (IP ou masque invalides
+2082 Réseau NetID informatique. S'il vous plaît, attendez...
+2083 <b>Erreur:</b> impossible de mettre à jour NetID!
+2084 NetID réseau a été calculé
 2085 étaient déjà calculés
 2086 ne sont pas calculables
-2087 Netmap netid computing. Please wait...
-2089 a été calculé netid NETMAP
+2087 Netmap NetID computing. Please wait...
+2089 NetID Netmap a été calculé
 2090 Effacement des orphelins...
-2091 ERREUR: Impossible d'effacer
+2091 <b>Erreur:</b> impossible d'effacer!
 2092 lignes orphelines supprimées
-2093 Suppression de NETMAP...
-2094 ERREUR: Impossible d'effacer NETMAP
-2095 lignes NETMAP supprimées
+2093 Suppression de Netmap...
+2094 <b>Erreur:</b> impossible d'effacer Netmap!
+2095 lignes Netmap supprimées
 2096 Entrer le label pour les clients windows (fenêtre de saisie lors du lancement du client):
 2097 Laissez vide si vous ne voulez pas qu'une popup s'affiche au premier lancement de l'agent
-2098 ERROR: ZIP for PHP is not properly installed.<br>Try uncommenting extension=php_zip.dll (Windows) by removing the semicolon in file php.ini, or try installing the libphp-pclzip package (Linux).
-2099 ERROR: ce compte MySQL n'a pas les droits de création de database
-2100 Update anciens accountinfos
+2098 <b>Erreur:</b> ZIP pour PHP n'est pas installé correctement.<br>Essayez de décommenter "extension=php_zip.dll" (Windows) en supprimant le point-virgule dans le fichier php.ini, ou essayez d'installer le paquet libphp-pclzip (Linux)!
+2099 <b>Erreur:</b> ce compte MySQL n'a pas les droits de création de database!
+2100 Update anciens information de comptes
 2101 Ajouté par script
-2102 ATTENTION: Si vous changer le nom de la base (ocsweb), pensez à modifier vos fichiers de conf moteur (file z-ocsinventory-server.conf)
-2103 Mode DEMO: vous ne pouvez mettre à jour les données
-2104 VOUS ETES SUR LA VERSION DE DEMO DE
+2102 <b>Avertissement:</b> si vous changer le nom de la base (OCSWEB) ou utilisateur (OCS), pensez à modifier vos fichiers de configuration moteur (z-ocsinventory-server.conf)!
+2103 Mode démo: vous ne pouvez pas mettre à jour les données
+2104 Vous etes sur la version de démo de 
 2105 Votre base de données est à jour.<br>Aucune action a effectuer.
-2106 La configuration max_allowed_packet de MySQL n'autorise que des fichiers de <
+2106 La configuration "max_allowed_packet" de MySQL n'autorise que des fichiers <
 2107 La version de votre interface WEB est inférieure à la version de la base de données
-2108 La version de la base de données doit <b>OBLIGATOIREMENT</b> être inférieure ou égale à la version de l'interface WEB
+2108 La version de la base de données doit <b>obligatoirement</b> être inférieure ou égale à la version de l'interface WEB
 2109 Version actuelle
 2110 Version attendue
 2111 Effectuer la mise à jour
 2112 Le fichier suivant n'est pas présent ou n'est pas accessible en lecture
-2113 La version actuelle de php est inférieure à la version 5.4 et ne sera plus compatible dans le futur (version&nbsp;:&nbsp;
-2114 Aucun fichier sql pour la version
+2113 La version actuelle de php est inférieure à 5.3.7 et ne sera plus compatible dans le futur (version: 
+2114 Aucun fichier sql pour la version 
 2115 L'utilisateur que vous avez tapé ne semble pas être root
-2116 Le répertoire config/profiles n'est pas disponible en écriture
+2116 Le répertoire configuration/profiles n'est pas disponible en écriture
 2117 Affiche un message si une mise a jour est disponible
 2118 OCSInventory
 2119 est disponible
@@ -1413,9 +1413,8 @@
 2122 Modification
 2123 Paquets disponible
 2124 Paquets supprimé
-
 5000 [DEBUG]requête d'insertion de machines =>[DEBUG]
-5001 [DEBUG]REQUETE JOUEE => [DEBUG]
+5001 [DEBUG]Requete jouee => [DEBUG]
 5002 [DEBUG] => poids: [DEBUG]
 5003 [DEBUG]Régénération du cache[DEBUG]
 5004 [DEBUG]forçage de la limite de cache ancienne valeur[DEBUG]
@@ -1423,34 +1422,32 @@
 5006 [DEBUG]requête count tableau[DEBUG]
 5007 [DEBUG]Utilisation du cache pour le nombre de lignes[DEBUG]
 5008 [DEBUG]requête du tableau[DEBUG]
-5009 [DEBUG]DONNEES BRUTES[DEBUG]
-5010 [DEBUG]champ de la table=[DEBUG]
+5009 [DEBUG]Donnees brutes[DEBUG]
+5010 [DEBUG]champ de la tableau=[DEBUG]
 5011 [DEBUG]champ de comparaison=[DEBUG]
 5012 [DEBUG]valeur à chercher=[DEBUG]
 5013 [DEBUG]Champ complémentaire=[DEBUG]
-5014 [DEBUG]Champ AND OR=[DEBUG]
-5015 [DEBUG]OUBLIE DU CHAMP COMPLEMENTAIRE SUR LA TABLE[DEBUG]
-5016 [DEBUG]table =>[DEBUG]
+5014 [DEBUG]Champ "and" "or"=[DEBUG]
+5015 [DEBUG]Oublie du champ complementaire sur la tableau[DEBUG]
+5016 [DEBUG]tableau =>[DEBUG]
 5017 [DEBUG]champ =>[DEBUG]
 5018 [DEBUG]comparaison =>[DEBUG]
 5019 [DEBUG]valeur à chercher =>[DEBUG]
 5020 [DEBUG]champ complémentaire =>[DEBUG]
-5021 [DEBUG]AND_OR =>[DEBUG]
-5022 [DEBUG]REQUETE CONDITION NORMALE[DEBUG]
-5023 [DEBUG]REQUETE CONDITION DIFF[DEBUG]
-
+5021 [DEBUG]and_or =>[DEBUG]
+5022 [DEBUG]Requete condition normale[DEBUG]
+5023 [DEBUG]Requete condition "diff"[DEBUG]
 6000 Plugins
-6001 Sélectionner la colonne à afficher / masquer
+6001 Sélectionner la colonne à afficher/masquer
 6003 Plugin
-6004 Nombre Total disponible
+6004 Nombre total disponible
 6005 Eteinte/allumée
-6006 AVERTISSEMENT : Le module php-soap n'est pas installé, le moteur de plugin ne fonctionnera pas.
-6007 Les modules suivants sont requis pour utiliser cette fonctionnalitée&nbsp;:&nbsp;
-6008 Les répertoires suivants ne sont pas accessibles en écriture&nbsp;:&nbsp;
-6009 Vous ne pouvez pas installer de plugins, référez vous aux erreurs ci-dessus.
-6010 Le serveur de communication a rencontré l'erreur suivante lors de l'installation&nbsp;:&nbsp;
+6006 <b>Avertissement:</b> le module php-soap n'est pas installé. Le moteur de plugin ne fonctionnera pas!
+6007 Les modules suivants sont nécessaires pour utiliser cette fonctionnalité:
+6008 Les répertoires suivants ne sont pas accessibles en écriture:
+6009 Vous ne pouvez pas installer de plugins. Référez vous aux erreurs ci-dessus.
+6010 Le serveur de communication a rencontré l'erreur suivante lors de l'installation:
 6011 Cliquez ici pour obtenir de l'aide
-
 7000 Plugins
 7001 Gestionnaire de plugins
 7002 Nom du plugin
@@ -1462,8 +1459,8 @@
 7008 Installer un plugin
 7009 Plugins installé
 7010 Ce plugin a déjà été installé
-7011 est un plugin non valide, vérifiez vos sources.
-7012 Installation annulée !
+7011 est un plugin non valide. Vérifiez vos sources.
+7012 Installation annulée!
 7013 installé
 7014 Il n'y a aucun plugin disponible
-7015 Sélectionnez au minimum un ordinateur !
+7015 Sélectionnez au minimum un ordinateur!


### PR DESCRIPTION
* Changes related with version 2.3:
	* Some duplicate codes have been removed;
	* Many missing codes in the brazilian portuguese version have been included/translated;
	* Many codes in the brazilian portuguese version still in english/french have been translated;
	* Many translations were retranslated considering contextualization;
	* Several translations were re-adapted;
	* Many problems of accentuation, uppercase and punctuation have been solved;
	* Many unused codes in the source code have been removed (brazilian portuguese, english and french);
	* Error and warning messages were normalized.
* On "828 Remove computers with inventory older than"
	* Q: Older than what?
* On "254 Path of the key (Ex: SOFTWARE\Mozilla)"
	* Q: Why the "\" is suppressed?
* On Management > Local import > Manual entry
	* Q: What is the meaning of "_M"?
	* Q: "28 Computer count" is really ok?
* The code 400 is used in function_snmp.php, but it is not on the language files
	* S: add the code and a pro